### PR TITLE
fix: bump httpclient5 to 5.6.3 (Dependabot #2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.6.1</version>
+            <version>5.6.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Bumps `org.apache.httpcomponents.client5:httpclient5` from `5.6.1` to `5.6.3` to resolve Dependabot alert **#2** (Medium, `>= 5.0-alpha1, < 5.6.3`).

- httpclient5 resolves to **5.6.3** (`mvn dependency:tree`)
- `mvn test` BUILD SUCCESS